### PR TITLE
Removes force-casting `RCTRefreshControl`'s superView to `UIScrollView`

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.h
+++ b/React/Views/RefreshControl/RCTRefreshControl.h
@@ -14,5 +14,6 @@
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
+@property (nonatomic, weak) UIScrollView *scrollView;
 
 @end

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -53,34 +53,43 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
   UInt64 beginRefreshingTimestamp = _currentRefreshingStateTimestamp;
   _refreshingProgrammatically = YES;
-  // When using begin refreshing we need to adjust the ScrollView content offset manually.
-  UIScrollView *scrollView = (UIScrollView *)self.superview;
+  
   // Fix for bug #24855
   [self sizeToFit];
-  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
+    
+    if (self.scrollView) {
+        
+        // When using begin refreshing we need to adjust the ScrollView content offset manually.
+      UIScrollView *scrollView = (UIScrollView *)self.scrollView;
+          
+      CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
 
-  // `beginRefreshing` must be called after the animation is done. This is why it is impossible
-  // to use `setContentOffset` with `animated:YES`.
-  [UIView animateWithDuration:0.25
-      delay:0
-      options:UIViewAnimationOptionBeginFromCurrentState
-      animations:^(void) {
-        [scrollView setContentOffset:offset];
-      }
-      completion:^(__unused BOOL finished) {
-        if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
-          [super beginRefreshing];
-          [self setCurrentRefreshingState:super.refreshing];
-        }
-      }];
+        // `beginRefreshing` must be called after the animation is done. This is why it is impossible
+        // to use `setContentOffset` with `animated:YES`.
+      [UIView animateWithDuration:0.25
+          delay:0
+          options:UIViewAnimationOptionBeginFromCurrentState
+          animations:^(void) {
+            [scrollView setContentOffset:offset];
+          }
+          completion:^(__unused BOOL finished) {
+            if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
+              [super beginRefreshing];
+              [self setCurrentRefreshingState:super.refreshing];
+            }
+          }];
+    } else if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
+      [super beginRefreshing];
+      [self setCurrentRefreshingState:super.refreshing];
+    }
 }
 
 - (void)endRefreshingProgrammatically
 {
   // The contentOffset of the scrollview MUST be greater than the contentInset before calling
   // endRefreshing otherwise the next pull to refresh will not work properly.
-  UIScrollView *scrollView = (UIScrollView *)self.superview;
-  if (_refreshingProgrammatically && scrollView.contentOffset.y < -scrollView.contentInset.top) {
+  UIScrollView *scrollView = self.scrollView;
+  if (scrollView && _refreshingProgrammatically && scrollView.contentOffset.y < -scrollView.contentInset.top) {
     UInt64 endRefreshingTimestamp = _currentRefreshingStateTimestamp;
     CGPoint offset = {scrollView.contentOffset.x, -scrollView.contentInset.top};
     [UIView animateWithDuration:0.25

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -230,6 +230,10 @@
     [_customRefreshControl removeFromSuperview];
   }
   _customRefreshControl = refreshControl;
+  // We have to set this because we can't always guarantee the
+  // `RCTCustomRefreshContolProtocol`'s superview will always be of class
+  // `UIScrollView` like we were previously
+  _customRefreshControl.scrollView = self;
   if ([refreshControl isKindOfClass:UIRefreshControl.class]) {
     self.refreshControl = (UIRefreshControl *)refreshControl;
   } else {

--- a/React/Views/ScrollView/RCTScrollableProtocol.h
+++ b/React/Views/ScrollView/RCTScrollableProtocol.h
@@ -37,5 +37,6 @@
 
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
 @property (nonatomic, readonly, getter=isRefreshing) BOOL refreshing;
+@property (nonatomic, weak) UIScrollView *scrollView;
 
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes a crash where in certain circumstances manually refreshing a `RefreshControl` would cause a crash on iOS due to it's `superView` being force-casted to `UIScrollView` (Resulting in an unrecognised selector crash when accessing it's contentOffset)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
